### PR TITLE
require pre-6.0.0 rdflib version for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rdflib
+rdflib<6.0.0
 pydantic==1.8.1
 email-validator
 jsonschema2md

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,18 @@ README = 'TODO'# (pathlib.Path(__file__).parent / "README.md").read_text()
 
 setup(
     name='hsmodels',
-    version='0.1.5',
+    version='0.1.6',
     packages=find_packages(include=['hsmodels', 'hsmodels.*', 'hsmodels.schemas.*', 'hsmodels.schemas.rdf.*'],
                            exclude=("tests",)),
     install_requires=[
-        'rdflib',
+        'rdflib<6.0.0',
         'pydantic==1.8.1',
         'email-validator'
     ],
     url='https://github.com/hydroshare/hsmodels',
     license='MIT',
     author='Scott Black',
-    author_email='scott.black@usu.edu',
+    author_email='sblack@cuahsi.org',
     description='Pydantic models for HydroShare metadata',
     python_requires='>=3.6',
     long_description=README,


### PR DESCRIPTION
`rdf_graph(schema).serialize(format=rdf_format)` returns a string in >=6.0.0, <6.0.0 returns bytes.   This PR enforces a compatible rdflib version until we implement a solution to be backwards compatible or make a decision to support the >=6.0.0 exclusively.
