### PR TITLE
determine type with form submissions of spatial reference

### DIFF
--- a/hsmodels/schemas/validators.py
+++ b/hsmodels/schemas/validators.py
@@ -5,6 +5,13 @@ from hsmodels.utils import to_coverage_dict
 def parse_spatial_reference(cls, value):
     if not value:
         return value
+    # This is a workaround for form submissions that do not include type
+    if isinstance(value, dict) and "type" not in value:
+        if "north" in value or "east" in value:
+            # it's a type point
+            value["type"] = "point"
+        else:
+            value["type"] = "box"
     if value['type'] == enums.SpatialReferenceType.box:
         return fields.BoxSpatialReference(**to_coverage_dict(value['value']))
     if value['type'] == enums.SpatialReferenceType.point:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -327,7 +327,15 @@ def test_aggregation_metadata_from_form():
             "method": None,
             "minimum_value": "2274.95898438",
         },
-        "spatial_reference": None,
+        "spatial_reference": {
+            "northlimit": 30.214583003567654,
+            "eastlimit": -97.92170777387547,
+            "southlimit": 30.127513332692264,
+            "westlimit": -98.01556648306897,
+            "units": "Decimal degrees",
+            "projection": "WGS 84 EPSG:4326",
+            "projection_string": "WGS 84 EPSG:4326",
+        },
         "cell_information": {
             "name": "logan.vrt",
             "rows": 230,
@@ -338,4 +346,5 @@ def test_aggregation_metadata_from_form():
         },
     }
     agg = GeographicRasterMetadata(**md)
+    assert agg.spatial_reference.type == "box"
     assert agg.spatial_coverage.type == "box"


### PR DESCRIPTION
Same workaround for spatial reference as we used for spatial coverage to determine the type based off the available keys.