### PR TITLE
push user identifiers out of dict field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ publish-docs:
 
 .PHONY: test
 test:
-	pytest tests
+	pytest tests -vv
 
 .PHONY: test-cov
 test-cov:

--- a/hsmodels/schemas/base_models.py
+++ b/hsmodels/schemas/base_models.py
@@ -100,7 +100,7 @@ class BaseMetadata(BaseModel):
                                 "title": "Key-Value",
                                 "description": "A key-value pair",
                                 "default": [],
-                                "properties": {"key": {"type": "string"}, "value": {"type": "string"}}
+                                "properties": {"key": {"type": "string"}, "value": {"type": "string"}},
                             }
 
 

--- a/hsmodels/schemas/enums.py
+++ b/hsmodels/schemas/enums.py
@@ -44,12 +44,6 @@ class VariableType(StringEnum):
     Unknown = 'Unknown'
 
 
-class UserIdentifierType(StringEnum):
-    google_scholar_id = "GoogleScholarID"
-    research_gate_id = "ResearchGateID"
-    ORCID = "ORCID"
-
-
 class RelationType(StringEnum):
     isPartOf = 'The content of this resource is part of'
     hasPart = 'This resource includes'

--- a/hsmodels/schemas/fields.py
+++ b/hsmodels/schemas/fields.py
@@ -170,6 +170,9 @@ class Creator(BaseMetadata):
     research_gate_id: AnyUrl = Field(
         default=None, title="Research Gate identifier", description="Identifier from https://www.researchgate.net/"
     )
+    researcher_id: AnyUrl = Field(
+        default=None, title="Research identifier", description="Identifier from https://researcherid.com/"
+    )
 
     _description_validator = validator("description", pre=True)(validate_user_url)
 
@@ -226,6 +229,9 @@ class Contributor(BaseMetadata):
     )
     research_gate_id: AnyUrl = Field(
         default=None, title="Research Gate identifier", description="Identifier from https://www.researchgate.net/"
+    )
+    researcher_id: AnyUrl = Field(
+        default=None, title="Research identifier", description="Identifier from https://researcherid.com/"
     )
 
     @classmethod

--- a/hsmodels/schemas/fields.py
+++ b/hsmodels/schemas/fields.py
@@ -5,8 +5,8 @@ from pydantic import AnyUrl, EmailStr, Field, HttpUrl, root_validator, validator
 
 from hsmodels.schemas import base_models
 from hsmodels.schemas.base_models import BaseMetadata
-from hsmodels.schemas.enums import ModelProgramFileType, RelationType, UserIdentifierType, VariableType
-from hsmodels.schemas.root_validators import group_user_identifiers, parse_relation, parse_utc_offset_value
+from hsmodels.schemas.enums import ModelProgramFileType, RelationType, VariableType
+from hsmodels.schemas.root_validators import parse_relation, parse_utc_offset_value
 from hsmodels.schemas.validators import validate_user_url
 
 
@@ -163,15 +163,15 @@ class Creator(BaseMetadata):
         description="A string containing the path to the hydroshare profile",
         allow_mutation=False,
     )
-    identifiers: Dict[UserIdentifierType, AnyUrl] = Field(
-        default={},
-        title="Creator identifiers",
-        description="A dictionary containing identifier types and URL links to alternative identifiers for the creator",
+    ORCID: AnyUrl = Field(default=None, title="ORCID identifier", description="Identifier from https://orcid.org/")
+    google_scholar_id: AnyUrl = Field(
+        default=None, title="Google Scholar identifier", description="Identifier from https://scholar.google.co.id/"
+    )
+    research_gate_id: AnyUrl = Field(
+        default=None, title="Research Gate identifier", description="Identifier from https://www.researchgate.net/"
     )
 
     _description_validator = validator("description", pre=True)(validate_user_url)
-
-    _split_identifiers = root_validator(pre=True, allow_reuse=True)(group_user_identifiers)
 
     @classmethod
     def from_user(cls, user):
@@ -220,13 +220,13 @@ class Contributor(BaseMetadata):
         description="A string containing the path to the hydroshare profile",
         allow_mutation=False,
     )
-    identifiers: Dict[UserIdentifierType, AnyUrl] = Field(
-        default={},
-        title="Contributor identifiers",
-        description="A dictionary containing identifier types and URL links to alternative identiers for the contributor",
+    ORCID: AnyUrl = Field(default=None, title="ORCID identifier", description="Identifier from https://orcid.org/")
+    google_scholar_id: AnyUrl = Field(
+        default=None, title="Google Scholar identifier", description="Identifier from https://scholar.google.co.id/"
     )
-
-    _split_identifiers = root_validator(pre=True, allow_reuse=True)(group_user_identifiers)
+    research_gate_id: AnyUrl = Field(
+        default=None, title="Research Gate identifier", description="Identifier from https://www.researchgate.net/"
+    )
 
     @classmethod
     def from_user(cls, user):

--- a/hsmodels/schemas/fields.py
+++ b/hsmodels/schemas/fields.py
@@ -163,7 +163,7 @@ class Creator(BaseMetadata):
         description="A string containing the path to the hydroshare profile",
         allow_mutation=False,
     )
-    ORCID: AnyUrl = Field(default=None, title="ORCID identifier", description="Identifier from https://orcid.org/")
+    orcid: AnyUrl = Field(default=None, title="ORCID identifier", description="Identifier from https://orcid.org/")
     google_scholar_id: AnyUrl = Field(
         default=None, title="Google Scholar identifier", description="Identifier from https://scholar.google.co.id/"
     )
@@ -220,7 +220,7 @@ class Contributor(BaseMetadata):
         description="A string containing the path to the hydroshare profile",
         allow_mutation=False,
     )
-    ORCID: AnyUrl = Field(default=None, title="ORCID identifier", description="Identifier from https://orcid.org/")
+    orcid: AnyUrl = Field(default=None, title="ORCID identifier", description="Identifier from https://orcid.org/")
     google_scholar_id: AnyUrl = Field(
         default=None, title="Google Scholar identifier", description="Identifier from https://scholar.google.co.id/"
     )

--- a/hsmodels/schemas/rdf/fields.py
+++ b/hsmodels/schemas/rdf/fields.py
@@ -23,7 +23,7 @@ from hsmodels.schemas.fields import (
     UTCOffSet,
     Variable,
 )
-from hsmodels.schemas.rdf.root_validators import parse_relation_rdf, rdf_parse_utc_offset, split_user_identifiers
+from hsmodels.schemas.rdf.root_validators import parse_relation_rdf, rdf_parse_utc_offset
 
 
 class RDFBaseModel(BaseModel):
@@ -105,8 +105,6 @@ class CreatorInRDF(RDFBaseModel):
     google_scholar_id: AnyUrl = Field(default=None)
     research_gate_id: AnyUrl = Field(default=None)
 
-    _group_identifiers = root_validator(pre=True, allow_reuse=True)(split_user_identifiers)
-
     class Config:
         fields = {
             'name': {"rdf_predicate": HSTERMS.name},
@@ -134,8 +132,6 @@ class ContributorInRDF(RDFBaseModel):
     ORCID: AnyUrl = Field(default=None)
     google_scholar_id: AnyUrl = Field(default=None)
     research_gate_id: AnyUrl = Field(default=None)
-
-    _group_identifiers = root_validator(pre=True, allow_reuse=True)(split_user_identifiers)
 
     class Config:
         fields = {

--- a/hsmodels/schemas/rdf/fields.py
+++ b/hsmodels/schemas/rdf/fields.py
@@ -104,6 +104,7 @@ class CreatorInRDF(RDFBaseModel):
     orcid: AnyUrl = Field(default=None)
     google_scholar_id: AnyUrl = Field(default=None)
     research_gate_id: AnyUrl = Field(default=None)
+    researcher_id: AnyUrl = Field(default=None)
 
     class Config:
         fields = {
@@ -111,6 +112,7 @@ class CreatorInRDF(RDFBaseModel):
             'creator_order': {"rdf_predicate": HSTERMS.creatorOrder},
             'google_scholar_id': {"rdf_predicate": HSTERMS.GoogleScholarID},
             'research_gate_id': {"rdf_predicate": HSTERMS.ResearchGateID},
+            'researcher_id': {"rdf_predicate": HSTERMS.ResearcherID},
             'phone': {"rdf_predicate": HSTERMS.phone},
             'orcid': {"rdf_predicate": HSTERMS.ORCID},
             'address': {"rdf_predicate": HSTERMS.address},
@@ -132,6 +134,7 @@ class ContributorInRDF(RDFBaseModel):
     orcid: AnyUrl = Field(default=None)
     google_scholar_id: AnyUrl = Field(default=None)
     research_gate_id: AnyUrl = Field(default=None)
+    researcher_id: AnyUrl = Field(default=None)
 
     class Config:
         fields = {
@@ -144,6 +147,7 @@ class ContributorInRDF(RDFBaseModel):
             'orcid': {"rdf_predicate": HSTERMS.ORCID},
             'google_scholar_id': {"rdf_predicate": HSTERMS.GoogleScholarID},
             'research_gate_id': {"rdf_predicate": HSTERMS.ResearchGateID},
+            'researcher_id': {"rdf_predicate": HSTERMS.ResearcherID},
             'description': {"rdf_predicate": HSTERMS.description},
         }
 

--- a/hsmodels/schemas/rdf/fields.py
+++ b/hsmodels/schemas/rdf/fields.py
@@ -101,7 +101,7 @@ class CreatorInRDF(RDFBaseModel):
     email: EmailStr = Field(default=None)
     homepage: HttpUrl = Field(default=None)
     description: str = Field(max_length=50, default=None)
-    ORCID: AnyUrl = Field(default=None)
+    orcid: AnyUrl = Field(default=None)
     google_scholar_id: AnyUrl = Field(default=None)
     research_gate_id: AnyUrl = Field(default=None)
 
@@ -112,7 +112,7 @@ class CreatorInRDF(RDFBaseModel):
             'google_scholar_id': {"rdf_predicate": HSTERMS.GoogleScholarID},
             'research_gate_id': {"rdf_predicate": HSTERMS.ResearchGateID},
             'phone': {"rdf_predicate": HSTERMS.phone},
-            'ORCID': {"rdf_predicate": HSTERMS.ORCID},
+            'orcid': {"rdf_predicate": HSTERMS.ORCID},
             'address': {"rdf_predicate": HSTERMS.address},
             'organization': {"rdf_predicate": HSTERMS.organization},
             'email': {"rdf_predicate": HSTERMS.email},
@@ -129,7 +129,7 @@ class ContributorInRDF(RDFBaseModel):
     email: EmailStr = Field(default=None)
     homepage: HttpUrl = Field(default=None)
     description: str = Field(max_length=50, default=None)
-    ORCID: AnyUrl = Field(default=None)
+    orcid: AnyUrl = Field(default=None)
     google_scholar_id: AnyUrl = Field(default=None)
     research_gate_id: AnyUrl = Field(default=None)
 
@@ -141,7 +141,7 @@ class ContributorInRDF(RDFBaseModel):
             'organization': {"rdf_predicate": HSTERMS.organization},
             'email': {"rdf_predicate": HSTERMS.email},
             'homepage': {"rdf_predicate": HSTERMS.homepage},
-            'ORCID': {"rdf_predicate": HSTERMS.ORCID},
+            'orcid': {"rdf_predicate": HSTERMS.ORCID},
             'google_scholar_id': {"rdf_predicate": HSTERMS.GoogleScholarID},
             'research_gate_id': {"rdf_predicate": HSTERMS.ResearchGateID},
             'description': {"rdf_predicate": HSTERMS.description},

--- a/hsmodels/schemas/rdf/root_validators.py
+++ b/hsmodels/schemas/rdf/root_validators.py
@@ -124,11 +124,3 @@ def parse_relation_rdf(cls, values):
     if "type" in values and "value" in values:
         values[values["type"].name] = values["value"]
     return values
-
-
-def split_user_identifiers(cls, values):
-    if "identifiers" in values:
-        identifiers = values["identifiers"]
-        for id_type, id_value in identifiers.items():
-            values[id_type.name] = id_value
-    return values

--- a/hsmodels/schemas/resource.py
+++ b/hsmodels/schemas/resource.py
@@ -24,7 +24,7 @@ from hsmodels.schemas.root_validators import (
     split_coverages,
     split_dates,
 )
-from hsmodels.schemas.validators import list_not_empty, parse_identifier,  parse_spatial_coverage
+from hsmodels.schemas.validators import list_not_empty, parse_identifier, parse_spatial_coverage
 
 
 class ResourceMetadataIn(BaseMetadata):

--- a/hsmodels/schemas/root_validators.py
+++ b/hsmodels/schemas/root_validators.py
@@ -1,4 +1,4 @@
-from hsmodels.schemas.enums import CoverageType, DateType, ModelProgramFileType, RelationType, UserIdentifierType
+from hsmodels.schemas.enums import CoverageType, DateType, ModelProgramFileType, RelationType
 from hsmodels.utils import to_coverage_dict
 
 
@@ -77,16 +77,6 @@ def parse_relation(cls, values):
             values["type"] = relation_type
             values["value"] = values[relation_type.name]
             return values
-
-
-def group_user_identifiers(cls, values):
-    if "identifiers" not in values:
-        identifiers = {}
-        for identifier in UserIdentifierType:
-            if identifier.name in values and values[identifier.name]:
-                identifiers[identifier] = values[identifier.name]
-        values["identifiers"] = identifiers
-    return values
 
 
 def parse_file_types(cls, values):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ README = 'Refer to the models section of https://hydroshare.github.io/hsclient/'
 
 setup(
     name='hsmodels',
-    version='0.4.5',
+    version='0.5.0',
     packages=find_packages(include=['hsmodels', 'hsmodels.*', 'hsmodels.schemas.*', 'hsmodels.schemas.rdf.*'],
                            exclude=("tests",)),
     install_requires=[

--- a/tests/data/json/resource.json
+++ b/tests/data/json/resource.json
@@ -40,7 +40,7 @@
       "homepage": "http://anthonycastronova.com",
       "google_scholar_id": "https://scholar.google.com/citations?user=ScWTFoQAAAAJ&hl=en",
       "research_gate_id": "https://www.researchgate.net/profile/Anthony_Castronova",
-      "ORCID": "https://orcid.org/0000-0002-1341-5681"
+      "orcid": "https://orcid.org/0000-0002-1341-5681"
     },
     {
       "name": "David Tarboton",
@@ -49,7 +49,7 @@
       "organization": "Utah State University",
       "email": "dtarb@usu.edu",
       "homepage": "http://hydrology.usu.edu/dtarb",
-      "ORCID": "https://orcid.org/0000-0002-1998-3479"
+      "orcid": "https://orcid.org/0000-0002-1998-3479"
     }
   ],
   "relations": [

--- a/tests/data/json/resource.json
+++ b/tests/data/json/resource.json
@@ -40,6 +40,7 @@
       "homepage": "http://anthonycastronova.com",
       "google_scholar_id": "https://scholar.google.com/citations?user=ScWTFoQAAAAJ&hl=en",
       "research_gate_id": "https://www.researchgate.net/profile/Anthony_Castronova",
+      "researcher_id": "https://researcherid.com/abc123",
       "orcid": "https://orcid.org/0000-0002-1341-5681"
     },
     {

--- a/tests/data/json/resource.json
+++ b/tests/data/json/resource.json
@@ -24,12 +24,10 @@
       "phone": "",
       "organization": "RENCI",
       "email": "test_user@email.com",
-      "description": "/user/1/",
-      "identifiers": {}
+      "description": "/user/1/"
     },
     {
-      "name": "Tseganeh Z. Gichamo",
-      "identifiers": {}
+      "name": "Tseganeh Z. Gichamo"
     }
   ],
   "contributors": [
@@ -40,11 +38,9 @@
       "organization": "CUAHSI",
       "email": "castronova.anthony@gmail.com",
       "homepage": "http://anthonycastronova.com",
-      "identifiers": {
-        "GoogleScholarID": "https://scholar.google.com/citations?user=ScWTFoQAAAAJ&hl=en",
-        "ResearchGateID": "https://www.researchgate.net/profile/Anthony_Castronova",
-        "ORCID": "https://orcid.org/0000-0002-1341-5681"
-      }
+      "google_scholar_id": "https://scholar.google.com/citations?user=ScWTFoQAAAAJ&hl=en",
+      "research_gate_id": "https://www.researchgate.net/profile/Anthony_Castronova",
+      "ORCID": "https://orcid.org/0000-0002-1341-5681"
     },
     {
       "name": "David Tarboton",
@@ -53,9 +49,7 @@
       "organization": "Utah State University",
       "email": "dtarb@usu.edu",
       "homepage": "http://hydrology.usu.edu/dtarb",
-      "identifiers": {
-        "ORCID": "https://orcid.org/0000-0002-1998-3479"
-      }
+      "ORCID": "https://orcid.org/0000-0002-1998-3479"
     }
   ],
   "relations": [

--- a/tests/data/metadata/resourcemetadata.xml
+++ b/tests/data/metadata/resourcemetadata.xml
@@ -85,6 +85,7 @@
         <hsterms:GoogleScholarID rdf:resource="https://scholar.google.com/citations?user=ScWTFoQAAAAJ&amp;hl=en"/>
         <hsterms:email>castronova.anthony@gmail.com</hsterms:email>
         <hsterms:homepage rdf:resource="http://anthonycastronova.com"/>
+        <hsterms:ResearcherID rdf:resource="https://researcherid.com/abc123"/>
         <hsterms:ResearchGateID rdf:resource="https://www.researchgate.net/profile/Anthony_Castronova"/>
         <hsterms:description>/user/11/</hsterms:description>
       </rdf:Description>

--- a/tests/data/metadata/resourcemetadata_with_point_coverage.xml
+++ b/tests/data/metadata/resourcemetadata_with_point_coverage.xml
@@ -114,6 +114,7 @@
         <hsterms:GoogleScholarID rdf:resource="https://scholar.google.com/citations?user=ScWTFoQAAAAJ&amp;hl=en"/>
         <hsterms:email>castronova.anthony@gmail.com</hsterms:email>
         <hsterms:homepage rdf:resource="http://anthonycastronova.com"/>
+        <hsterms:ResearcherID rdf:resource="https://researcherid.com/abc123"/>
         <hsterms:ResearchGateID rdf:resource="https://www.researchgate.net/profile/Anthony_Castronova"/>
       </rdf:Description>
     </dc:contributor>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -7,7 +7,7 @@ from rdflib.compare import _squashed_graphs_triples
 
 from hsmodels.namespaces import RDF
 from hsmodels.schemas import load_rdf, rdf_graph
-from hsmodels.schemas.enums import RelationType, UserIdentifierType
+from hsmodels.schemas.enums import RelationType
 from hsmodels.schemas.fields import BoxCoverage, PeriodCoverage, PointCoverage
 from hsmodels.utils import to_coverage_dict
 
@@ -111,7 +111,7 @@ def test_resource_metadata(res_md):
     assert contributor.address == "Utah, US"
     assert contributor.homepage == "http://hydrology.usu.edu/dtarb"
     assert contributor.organization == "Utah State University"
-    assert contributor.identifiers[UserIdentifierType.ORCID] == "https://orcid.org/0000-0002-1998-3479"
+    assert contributor.ORCID == "https://orcid.org/0000-0002-1998-3479"
     assert contributor.name == "David Tarboton"
 
     assert len(res_md.relations) == 3

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -111,7 +111,7 @@ def test_resource_metadata(res_md):
     assert contributor.address == "Utah, US"
     assert contributor.homepage == "http://hydrology.usu.edu/dtarb"
     assert contributor.organization == "Utah State University"
-    assert contributor.ORCID == "https://orcid.org/0000-0002-1998-3479"
+    assert contributor.orcid == "https://orcid.org/0000-0002-1998-3479"
     assert contributor.name == "David Tarboton"
 
     assert len(res_md.relations) == 3

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -81,5 +81,5 @@ def test_dictionary_field(additional_metadata_field):
             "title": "Key-Value",
             "description": "A key-value pair",
             "default": [],
-            "properties": {"key": {"type": "string"}, "value": {"type": "string"}}
+            "properties": {"key": {"type": "string"}, "value": {"type": "string"}},
         }


### PR DESCRIPTION
This is a change to the resource metadata user-facing schema.  While working on the Creator/Contributor identifier form generated from the json schema for DSP, I found that organizing the identifiers in a dictionary is not supported in the form generation.  

I think this organization is a little easier to use anyways.

This also has me thinking, what if we allowed user's to attach a json schema to the additional_metadata field?  It could be useful to attach more than key/value pairs of strings.  It would also be easier to work with and allow users to organize their data in their own way