### PR TITLE
ensure pydantic < v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rdflib<6.0.0
-pydantic>=1.8.1
+pydantic~=1.8.1
 email-validator
 jsonschema2md
 black

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
                            exclude=("tests",)),
     install_requires=[
         'rdflib<6.0.0',
-        'pydantic>=1.8.1',
+        'pydantic~=1.8.1',
         'email-validator'
     ],
     url='https://github.com/hydroshare/hsmodels',


### PR DESCRIPTION
Pydantic v2 was released last week
hsmodels install doesn't pin pydantic version and our schema syntax is not compatible with v2 yet. So for now we need to pin our pydantic version or things break.